### PR TITLE
Insert line break on JWT ttl time

### DIFF
--- a/lib/livedub_web/resolvers/accounts_resolver.ex
+++ b/lib/livedub_web/resolvers/accounts_resolver.ex
@@ -3,7 +3,8 @@ defmodule LivedubWeb.AccountsResolver do
 
   def sign_up(_root, args, _info) do
     with {:ok, %User{} = user} <- Accounts.create_user(args),
-         {:ok, jwt, _claims} <- Guardian.encode_and_sign(user, %{}, token_type: "access", ttl: {2, :minutes}) do
+         {:ok, jwt, _claims} <-
+           Guardian.encode_and_sign(user, %{}, token_type: "access", ttl: {2, :minutes}) do
       {:ok, %{user: user, access_token: jwt}}
     else
       {:error, changeset} ->
@@ -13,7 +14,8 @@ defmodule LivedubWeb.AccountsResolver do
 
   def sign_in(_root, %{email: email, password: password}, _info) do
     with {:ok, %User{} = user} <- Accounts.get_user_and_verify_password(email, password),
-         {:ok, jwt, _claims} <- Guardian.encode_and_sign(user, %{}, token_type: "access", ttl: {2, :minutes}) do
+         {:ok, jwt, _claims} <-
+           Guardian.encode_and_sign(user, %{}, token_type: "access", ttl: {2, :minutes}) do
       {:ok, %{user: user, access_token: jwt}}
     else
       {:error, _} ->


### PR DESCRIPTION
Running `mix format` after the previous commit inserts a newline at its diffs, due to the line length limit.